### PR TITLE
Added gil_scoped_release to Hdlcpp read and write methods.

### DIFF
--- a/python/Phdlcpp.cpp
+++ b/python/Phdlcpp.cpp
@@ -31,8 +31,8 @@ PYBIND11_MODULE(phdlcpp, m)
                 bytes = 0;
 
             return pybind11::bytes(reinterpret_cast<char *>(data), bytes);
-        })
+        }, pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("write", [](Hdlcpp::Hdlcpp *hdlcpp, char *data, uint16_t length) {
             return hdlcpp->write(reinterpret_cast<uint8_t *>(data), length);
-        });
+        }, pybind11::call_guard<pybind11::gil_scoped_release>());
 }

--- a/python/hdlcppserial.py
+++ b/python/hdlcppserial.py
@@ -7,6 +7,9 @@ class HdlcppSerial(Hdlcpp):
         self.serial = Serial(port, baudrate)
         super().__init__(self._transportRead, self._transportWrite, bufferSize, writeTimeout, writeRetries)
 
+    def stop(self):
+        self.serial.cancel_read()
+
     def _transportRead(self, length):
         return self.serial.read(length)
 


### PR DESCRIPTION
This enables the usage of a python thread for doing reads, while writing
with another.