### PR TITLE
hdlcpp: Change private to protected to facilitate overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 .build*
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,31 @@ project(hdlcpp)
 cmake_minimum_required(VERSION 3.1)
 
 add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE include)
+
+include(GNUInstallDirs)
+
+target_include_directories(${PROJECT_NAME}
+    INTERFACE ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME})
+
+install(FILES include/Hdlcpp.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hdlcpp)
+
+install(EXPORT ${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    NAMESPACE hdlcpp:: FILE ${PROJECT_NAME}-config.cmake
+    EXPORT_LINK_INTERFACE_LIBRARIES
+)
 
 if (BUILD_HDLCPP_MAIN)
+    include_directories(include)
     add_library(${PROJECT_NAME}-main src/main.cpp)
     target_include_directories(${PROJECT_NAME}-main PUBLIC include)
 endif()
 
 if (BUILD_TESTING)
+    include_directories(include)
     if (BUILD_EXTERNAL)
         add_subdirectory(src)
     endif()

--- a/include/Hdlcpp.hpp
+++ b/include/Hdlcpp.hpp
@@ -159,7 +159,7 @@ public:
         stopped = true;
     }
 
-private:
+protected:
     enum Frame {
         FrameData,
         FrameAck,


### PR DESCRIPTION
Prior to this change, overriding read or write made no sense because the framing and
encoding functions were behind a private wall and would require one to re-implement all
those functions unfortunately making this library less useful. For example, for a high
speed bus of 200 Mbps with 8b/10b encoding at the hardware layer, having a processor
wait for acks kills throughput. In that instance we are interested in the framing,
encoding and reading functions. This change makes such a scenario possible.