### PR TITLE
Facilitate overrides

### DIFF
--- a/include/Hdlcpp.hpp
+++ b/include/Hdlcpp.hpp
@@ -159,7 +159,7 @@ public:
         stopped = true;
     }
 
-private:
+protected:
     enum Frame {
         FrameData,
         FrameAck,

--- a/test/src/TestHdlcpp.cpp
+++ b/test/src/TestHdlcpp.cpp
@@ -1,7 +1,7 @@
 #include <catch.hpp>
 #include "turtle/catch.hpp"
 
-#define private public
+#define protected public
 #include "Hdlcpp.hpp"
 
 class HdlcppFixture {


### PR DESCRIPTION
Prior to this change, overriding read or write made no sense because the framing and
encoding functions were behind a private wall and would require one to re-implement all
those functions unfortunately making this library less useful. For example, for a high
speed bus of 200 Mbps with 8b/10b encoding at the hardware layer, having a processor
wait for acks kills throughput. In that instance we are interested in the framing,
encoding and reading functions. This change makes such a scenario possible.