### PR TITLE
hdlcpp: Disable write timeout when timeout value is set to zero

### DIFF
--- a/include/Hdlcpp.hpp
+++ b/include/Hdlcpp.hpp
@@ -136,6 +136,9 @@ public:
             if ((result = writeFrame(FrameData, writeSequenceNumber, data, length)) <= 0)
                 break;
 
+            if (writeTimeout == 0)
+                break;
+
             for (uint16_t i = 0; i < writeTimeout; i++) {
                 result = writeResult;
                 if (result >= 0) {


### PR DESCRIPTION
It seems fair to interpret a write timeout of zero to mean block (wait forever) or disable
timeout function. The latter makes the most sense since there are likely not many
cases where anyone would want a blocking call without the ability to terminate it.

closes #27 

Signed-off-by: Edward Kigwana <ekigwana@gmail.com>