### PR TITLE
Add Clang format rules and run on all files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,27 @@
+---
+BasedOnStyle: WebKit
+Standard: c++20
+NamespaceIndentation: None
+AlignEscapedNewlinesLeft: true
+MaxEmptyLinesToKeep: 2
+FixNamespaceComments: true
+SortIncludes: true
+SpaceInEmptyBlock: true
+PointerAlignment: Left
+AllowShortBlocksOnASingleLine: Empty
+IncludeCategories:
+  # Headers from catch or turtle must come first
+  - Regex:           '(catch)|(turtle)'
+    Priority:        1
+  # Headers in <> without extension.
+  - Regex:           '<([A-Za-z0-9\/-_])+>'
+    Priority:        4
+  # Headers in <> with extension.
+  - Regex:           '<([A-Za-z0-9./-_])+>'
+    Priority:        3
+  # Headers in "" with extension.
+  - Regex:           '"([A-Za-z0-9./-])+"'
+    Priority:        2
+ForEachMacros: ['foreach', 'BOOST_FOREACH']
+...
+

--- a/python/Phdlcpp.cpp
+++ b/python/Phdlcpp.cpp
@@ -1,7 +1,7 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/functional.h>
-#include <memory>
 #include "../include/Hdlcpp.hpp"
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <memory>
 
 using Pybind11Read = std::function<char(int)>;
 using Pybind11Write = std::function<int(pybind11::bytes)>;
@@ -10,7 +10,7 @@ PYBIND11_MODULE(phdlcpp, m)
 {
     pybind11::class_<Hdlcpp::Hdlcpp>(m, "Hdlcpp")
         .def(pybind11::init([](Pybind11Read read, Pybind11Write write, size_t bufferSize,
-            uint16_t writeTimeout, uint8_t writeRetries) {
+                                uint16_t writeTimeout, uint8_t writeRetries) {
             std::vector<Hdlcpp::value_type> readBuffer(bufferSize), writeBuffer(bufferSize);
             return std::make_unique<Hdlcpp::Hdlcpp>(
                 [read](Hdlcpp::Container buffer) {
@@ -21,25 +21,31 @@ PYBIND11_MODULE(phdlcpp, m)
                     return length;
                 },
                 [write](Hdlcpp::ConstContainer buffer) {
-                    return write(pybind11::bytes(reinterpret_cast<const char *>(buffer.data()), buffer.size()));
+                    return write(pybind11::bytes(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
                 },
                 readBuffer,
                 writeBuffer,
                 writeTimeout, writeRetries);
         }))
-        .def("read", [](Hdlcpp::Hdlcpp *hdlcpp, uint16_t length) {
-            int bytes;
-            uint8_t data[length];
+        .def(
+            "read", [](Hdlcpp::Hdlcpp* hdlcpp, uint16_t length) {
+                int bytes;
+                uint8_t data[length];
 
-            if ((bytes = hdlcpp->read({data, length})) < 0)
-                bytes = 0;
+                if ((bytes = hdlcpp->read({ data, length })) < 0)
+                    bytes = 0;
 
-            return pybind11::bytes(reinterpret_cast<char *>(data), bytes);
-        }, pybind11::call_guard<pybind11::gil_scoped_release>())
-        .def("write", [](Hdlcpp::Hdlcpp *hdlcpp, char *data, uint16_t length) {
-            return hdlcpp->write({reinterpret_cast<uint8_t *>(data), length});
-        }, pybind11::call_guard<pybind11::gil_scoped_release>())
-        .def("close", [](Hdlcpp::Hdlcpp *hdlcpp) {
-            hdlcpp->close();
-        }, pybind11::call_guard<pybind11::gil_scoped_release>());
+                return pybind11::bytes(reinterpret_cast<char*>(data), bytes);
+            },
+            pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def(
+            "write", [](Hdlcpp::Hdlcpp* hdlcpp, char* data, uint16_t length) {
+                return hdlcpp->write({ reinterpret_cast<uint8_t*>(data), length });
+            },
+            pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def(
+            "close", [](Hdlcpp::Hdlcpp* hdlcpp) {
+                hdlcpp->close();
+            },
+            pybind11::call_guard<pybind11::gil_scoped_release>());
 }


### PR DESCRIPTION
Default clang format rules seemed to reduce readability.

NOTE: This is pure formatting and have therefore no functional changes.