### PR TITLE
fix getting stuck with a full buffer without a valid frame

### DIFF
--- a/include/Hdlcpp.hpp
+++ b/include/Hdlcpp.hpp
@@ -89,6 +89,12 @@ public:
         return m_tail;
     }
 
+    void clear()
+    {
+        m_head = m_buffer.begin();
+        m_tail = m_head;
+    }
+
 private:
     Container m_buffer {};
     typename Container::iterator m_head { m_buffer.begin() };
@@ -161,6 +167,12 @@ public:
                 result = decode(address, readFrame, readSequenceNumber, readBuffer.dataSpan(), buffer, discardBytes);
                 if (result >= 0) {
                     doTransportRead = false;
+                } else if (readBuffer.unusedSpan().size() == 0) {
+                    // Drop the buffer in an attempt to recover from getting
+                    // filled with an invalid message.
+                    // FIXME: really start/stop codes should be tracked to
+                    //        implement this in a more fail-safe way
+                    readBuffer.clear();
                 }
             }
 

--- a/include/Hdlcpp.hpp
+++ b/include/Hdlcpp.hpp
@@ -84,8 +84,8 @@ public:
             for (const auto& byte : toBeMoved) {
                 *first++ = byte;
             }
-            m_tail = first;
         }
+        m_tail = first;
         return m_tail;
     }
 


### PR DESCRIPTION
See the commits for details.

Tl;dr if one is to fill the entire read-buffer with data, which doesn't contain an entire valid hdlc frame, the library would get completely stuck. Rather than only erasing from the read-buffer upon successful decoding, clear the buffer entirely if it is full and decoding fails.