### PR TITLE
Protect transportWrite with writeMutex

### DIFF
--- a/include/Hdlcpp.hpp
+++ b/include/Hdlcpp.hpp
@@ -440,6 +440,8 @@ protected:
 
     int writeFrame(TransportAddress address, Frame frame, uint8_t sequenceNumber, ConstContainer data)
     {
+        std::lock_guard<std::mutex> writeLock(writeFrameMutex);
+
         int result;
 
         if ((result = encode(address, frame, sequenceNumber, data, { writeBuffer })) < 0)
@@ -550,7 +552,11 @@ protected:
     static constexpr uint8_t FlagSequence = 0x7e;
     static constexpr uint8_t ControlEscape = 0x7d;
 
+    // Whenever writeMutex and writeFrameMutex both needs to be locked from the
+    // same thread, writeMutex must be locked first.
     std::mutex writeMutex;
+    std::mutex writeFrameMutex;
+
     TransportRead transportRead;
     TransportWrite transportWrite;
     Buffer<uint8_t> readBuffer;


### PR DESCRIPTION
Guard usage of the `transportWrite` and encoding frames into the `writeBuffer` by locking the `writeMutex` within `writeFrame` rather than only within `write`.

The `write` function relies on repeated call to `read` that need to be performed by a separate thread from the user of hdlcpp. This is because `write` will block until a `frameAck` or `frameNack` is received or a timeout is hit.
The hdlcpp implementation, however, also performs writes on the transport layer from within the `read` function itself. It does so in the process of either sending a `frameAck` or `frameNack` upon receival of a data frame.

From this it is aparent that any user of hdlcpp is basically forced into a race condition that can potentially mangle frames on the wire. The race can be hit by simply receiving data frames while trying to transmit data frames as well.
Since the function which actually encodes data into the `writeBuffer` and calls the `transportWrite` callback is `writeFrame` the `write` mutex should be locked here and not on the `write` function. This makes sure that if the thread handling `read` were to attempt transmitting a `frameAck` while another thread was attempting to transmit a data frame, then these two frames don't get mixed together.

Of course, one can argue that now the `write` API is not "thread safe" since it doesn't have its own distinct mutex. However, it should be fair to place the burden of thread safety for calls _into_ `write` on the user of the respective hdlcpp instance.